### PR TITLE
Prevent a crash if the SenderID is nil

### DIFF
--- a/server.go
+++ b/server.go
@@ -752,7 +752,7 @@ func (s *Server) getPeers(addr Addr, infoHash int160, callback func(krpc.Msg, er
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		s.addResponseNodes(m)
-		if m.R != nil && m.R.Token != "" {
+		if m.R != nil && m.R.Token != "" && m.SenderID() != nil {
 			if n, _ := s.getNode(addr, int160FromByteArray(*m.SenderID()), false); n != nil {
 				n.announceToken = m.R.Token
 			}


### PR DESCRIPTION
Very similar to https://github.com/anacrolix/dht/commit/faa1d74e0e543f84e74b4ee302455c6908b19ed0 but just after the callback is called.