### PR TITLE
stop traversal to plug a resource leak when returning an error

### DIFF
--- a/announce.go
+++ b/announce.go
@@ -75,6 +75,7 @@ func (s *Server) Announce(infoHash [20]byte, port int, impliedPort bool, opts ..
 	})
 	nodes, err := s.TraversalStartingNodes()
 	if err != nil {
+		a.traversal.Stop()
 		return
 	}
 	a.traversal.AddNodes(nodes)


### PR DESCRIPTION
When the torrent CLI program is started without network connectivity, it
busy-loops with error message:

torrent.go:1700: "distri-qemu-serial.img.zst": error announcing
\""distri-qemu-serial.img.zst\"" to DHT: getting starting nodes:
nothing resolved

Before this commit, this busy-loop combined with the resource leak would quickly
consume all available memory on the machine, making Linux invoke the OOM
killer (in the best case) or run out of memory and just hang (in my case).

This commit plugs the resource leak, meaning the torrent CLI can now print
errors all day long without consuming all the machine’s memory.