### PR TITLE
Use uint32 atomics

### DIFF
--- a/announce.go
+++ b/announce.go
@@ -40,8 +40,8 @@ func (a *Announce) String() string {
 }
 
 // Returns the number of distinct remote addresses the announce has queried.
-func (a *Announce) NumContacted() int64 {
-	return atomic.LoadInt64(&a.traversal.Stats().NumAddrsTried)
+func (a *Announce) NumContacted() uint32 {
+	return atomic.LoadUint32(&a.traversal.Stats().NumAddrsTried)
 }
 
 type AnnounceOpt *struct{}

--- a/traversal/operation.go
+++ b/traversal/operation.go
@@ -206,7 +206,7 @@ func (op *Operation) startQuery() {
 			op.cond.Broadcast()
 		}()
 		//log.Printf("traversal querying %v", a)
-		atomic.AddInt64(&op.stats.NumAddrsTried, 1)
+		atomic.AddUint32(&op.stats.NumAddrsTried, 1)
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
 			select {
@@ -221,7 +221,7 @@ func (op *Operation) startQuery() {
 			func() {
 				op.mu.Lock()
 				defer op.mu.Unlock()
-				atomic.AddInt64(&op.stats.NumResponses, 1)
+				atomic.AddUint32(&op.stats.NumResponses, 1)
 				op.addClosest(*res.ResponseFrom, res.ClosestData)
 			}()
 		}

--- a/traversal/stats.go
+++ b/traversal/stats.go
@@ -6,9 +6,9 @@ import (
 
 type Stats struct {
 	// Count of (probably) distinct addresses we've sent traversal queries to. Accessed with atomic.
-	NumAddrsTried int64
+	NumAddrsTried uint32
 	// Number of responses we received to queries related to this traversal. Accessed with atomic.
-	NumResponses int64
+	NumResponses uint32
 }
 
 func (me Stats) String() string {


### PR DESCRIPTION
int64 atomics are not supported on 32-bit systems as of now: https://github.com/golang/go/issues/599. I doubt the changed variables will ever exceed UINT32_MAX

I tested this on an x86-32 system with success. I'll make a write-up on the necessary configurations to run anacrolix/torrent (v1.30.0 as of the time of writing) on Android. @anacrolix, please let me know if you need this before approving the PR.

Many thanks for the fantastic project :heart: 