### PR TITLE
Add NodeAddr equality and search methods

### DIFF
--- a/krpc/CompactIPv4NodeAddrs.go
+++ b/krpc/CompactIPv4NodeAddrs.go
@@ -23,3 +23,7 @@ func (me *CompactIPv4NodeAddrs) UnmarshalBencode(b []byte) error {
 func (me CompactIPv4NodeAddrs) NodeAddrs() []NodeAddr {
 	return me
 }
+
+func (me CompactIPv4NodeAddrs) Index(x NodeAddr) int {
+	return addrIndex(me, x)
+}

--- a/krpc/CompactIPv6NodeAddrs.go
+++ b/krpc/CompactIPv6NodeAddrs.go
@@ -28,3 +28,7 @@ func (me *CompactIPv6NodeAddrs) UnmarshalBencode(b []byte) error {
 func (me CompactIPv6NodeAddrs) NodeAddrs() []NodeAddr {
 	return me
 }
+
+func (me CompactIPv6NodeAddrs) Index(x NodeAddr) int {
+	return addrIndex(me, x)
+}

--- a/krpc/compact_helpers.go
+++ b/krpc/compact_helpers.go
@@ -72,3 +72,13 @@ func bencodeBytesResult(b []byte, err error) ([]byte, error) {
 	}
 	return bencode.Marshal(b)
 }
+
+// returns position of x in v, or -1 if not found
+func addrIndex(v []NodeAddr, x NodeAddr) int {
+	for i := 0; i < len(v); i += 1 {
+		if v[i].Equal(x) {
+			return i
+		}
+	}
+	return -1
+}

--- a/krpc/compact_test.go
+++ b/krpc/compact_test.go
@@ -17,3 +17,45 @@ func TestUnmarshalSlice(t *testing.T) {
 	assert.Equal(t, "1.2.3.4", data[0].Addr.IP.String())
 	assert.Equal(t, "2.3.4.5", data[1].Addr.IP.String())
 }
+
+var nodeAddrIndexTests4 = []struct {
+	v   CompactIPv4NodeAddrs
+	a   NodeAddr
+	out int
+}{
+	{[]NodeAddr{{IPv4(172, 16, 1, 1), 11}, {IPv4(192, 168, 0, 3), 11}}, NodeAddr{IPv4(172, 16, 1, 1), 11}, 0},
+	{[]NodeAddr{{IPv4(172, 16, 1, 1), 11}, {IPv4(192, 168, 0, 3), 11}}, NodeAddr{IPv4(192, 168, 0, 3), 11}, 1},
+	{[]NodeAddr{{IPv4(172, 16, 1, 1), 11}, {IPv4(192, 168, 0, 3), 11}}, NodeAddr{IPv4(127, 0, 0, 1), 11}, -1},
+	{[]NodeAddr{}, NodeAddr{IPv4(127, 0, 0, 1), 11}, -1},
+	{[]NodeAddr{}, NodeAddr{}, -1},
+}
+
+func TestNodeAddrIndex4(t *testing.T) {
+	for _, tc := range nodeAddrIndexTests4 {
+		out := tc.v.Index(tc.a)
+		if out != tc.out {
+			t.Errorf("CompactIPv4NodeAddrs(%v).Index(%v) = %v, want %v", tc.v, tc.a, out, tc.out)
+		}
+	}
+}
+
+var nodeAddrIndexTests6 = []struct {
+	v   CompactIPv6NodeAddrs
+	a   NodeAddr
+	out int
+}{
+	{[]NodeAddr{{ParseIP("2001::1"), 11}, {ParseIP("4004::1"), 11}}, NodeAddr{ParseIP("2001::1"), 11}, 0},
+	{[]NodeAddr{{ParseIP("2001::1"), 11}, {ParseIP("4004::1"), 11}}, NodeAddr{ParseIP("4004::1"), 11}, 1},
+	{[]NodeAddr{{ParseIP("2001::1"), 11}, {ParseIP("4004::1"), 11}}, NodeAddr{ParseIP("::1"), 11}, -1},
+	{[]NodeAddr{}, NodeAddr{ParseIP("::1"), 11}, -1},
+	{[]NodeAddr{}, NodeAddr{}, -1},
+}
+
+func TestNodeAddrIndex6(t *testing.T) {
+	for _, tc := range nodeAddrIndexTests6 {
+		out := tc.v.Index(tc.a)
+		if out != tc.out {
+			t.Errorf("CompactIPv6NodeAddrs(%v).Index(%v) = %v, want %v", tc.v, tc.a, out, tc.out)
+		}
+	}
+}

--- a/krpc/nodeaddr.go
+++ b/krpc/nodeaddr.go
@@ -60,3 +60,7 @@ func (me *NodeAddr) FromUDPAddr(ua *net.UDPAddr) {
 	me.IP = ua.IP
 	me.Port = ua.Port
 }
+
+func (me NodeAddr) Equal(x NodeAddr) bool {
+	return me.IP.Equal(x.IP) && me.Port == x.Port
+}

--- a/krpc/nodeaddr_test.go
+++ b/krpc/nodeaddr_test.go
@@ -1,14 +1,43 @@
 package krpc
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	IPv4    = net.IPv4
+	ParseIP = net.ParseIP
+)
+
 func TestUnmarshalNodeAddr(t *testing.T) {
 	var na NodeAddr
 	require.NoError(t, na.UnmarshalBinary([]byte("\x01\x02\x03\x04\x05\x06")))
 	assert.EqualValues(t, "1.2.3.4", na.IP.String())
+}
+
+var naEqualTests = []struct {
+	a, b NodeAddr
+	out  bool
+}{
+	{NodeAddr{IPv4(172, 16, 1, 1), 11}, NodeAddr{IPv4(172, 16, 1, 1), 11}, true},
+	{NodeAddr{IPv4(172, 16, 1, 1), 11}, NodeAddr{IPv4(172, 16, 1, 1), 22}, false},
+	{NodeAddr{IPv4(172, 16, 1, 1), 11}, NodeAddr{IPv4(192, 168, 0, 3), 11}, false},
+	{NodeAddr{IPv4(172, 16, 1, 1), 11}, NodeAddr{IPv4(192, 168, 0, 3), 22}, false},
+	{NodeAddr{ParseIP("2001:db8:1:2::1"), 11}, NodeAddr{ParseIP("2001:db8:1:2::1"), 11}, true},
+	{NodeAddr{ParseIP("2001:db8:1:2::1"), 11}, NodeAddr{ParseIP("2001:db8:1:2::1"), 22}, false},
+	{NodeAddr{ParseIP("2001:db8:1:2::1"), 11}, NodeAddr{ParseIP("fe80::420b"), 11}, false},
+	{NodeAddr{ParseIP("2001:db8:1:2::1"), 11}, NodeAddr{ParseIP("fe80::420b"), 22}, false},
+}
+
+func TestNodeAddrEqual(t *testing.T) {
+	for _, tc := range naEqualTests {
+		out := tc.a.Equal(tc.b)
+		if out != tc.out {
+			t.Errorf("NodeAddr(%v).Equal(%v) = %v, want %v", tc.a, tc.b, out, tc.out)
+		}
+	}
 }


### PR DESCRIPTION
Add `NodeAddr.Equal()` and `CompactIPv[46]NodeAddrs.Index()` methods.

Lifted from the PEX code in anacrolix/torrent.

@anacrolix 