### PR TITLE
add IP.To4 mapping to CompactIPv4NodeAddrs.MarshalBinary

### DIFF
--- a/krpc/CompactIPv4NodeAddrs.go
+++ b/krpc/CompactIPv4NodeAddrs.go
@@ -1,11 +1,18 @@
 package krpc
 
+import "github.com/anacrolix/missinggo/slices"
+
 type CompactIPv4NodeAddrs []NodeAddr
 
 func (CompactIPv4NodeAddrs) ElemSize() int { return 6 }
 
 func (me CompactIPv4NodeAddrs) MarshalBinary() ([]byte, error) {
-	return marshalBinarySlice(me)
+	return marshalBinarySlice(slices.Map(func(addr NodeAddr) NodeAddr {
+		if a:= addr.IP.To4(); a != nil {
+			addr.IP = a
+		}
+		return addr
+	}, me).(CompactIPv4NodeAddrs))
 }
 
 func (me CompactIPv4NodeAddrs) MarshalBencode() ([]byte, error) {


### PR DESCRIPTION
`CompactIPv4NodeAddrs.MarshalBinary` can not serialise results of `net.IPv4` directly, requiring additional `To4` call.

The included test flags the issue:
```
--- FAIL: TestMarshalCompactIPv4NodeAddrs (0.00s)
panic: marshalled 18 bytes, but expected 6 [recovered]
	panic: marshalled 18 bytes, but expected 6
```

The proposed fix is to take same approach as in `CompactIPv4NodeInfo.MarshalBinary`.

Fixes #33.