### PR TITLE
[announce] Fix race condition when adding peers

### DIFF
--- a/announce.go
+++ b/announce.go
@@ -115,10 +115,13 @@ func (s *Server) AnnounceTraversal(infoHash [20]byte, opts ...AnnounceOpt) (_ *A
 		for {
 			select {
 			case psv := <-a.values:
+				// We received a new value. Handle it before checking if
+				// traversal stopped
+				a.Peers <- psv
 				select {
-				case a.Peers <- psv:
 				case <-a.traversal.Stopped():
 					return
+				default:
 				}
 			case <-a.traversal.Stopped():
 				return

--- a/server.go
+++ b/server.go
@@ -437,7 +437,7 @@ func filterPeers(querySourceIp net.IP, queryWants []krpc.Want, allPeers []krpc.N
 				return nil, false
 			}
 		}(peer.IP); ok {
-			filtered = append(filtered, krpc.NodeAddr{ip, peer.Port})
+			filtered = append(filtered, krpc.NodeAddr{IP: ip, Port: peer.Port})
 		}
 	}
 	return
@@ -544,7 +544,7 @@ func (s *Server) handleQuery(source Addr, m krpc.Msg) {
 		if ps := s.config.PeerStore; ps != nil {
 			go ps.AddPeer(
 				peer_store.InfoHash(args.InfoHash),
-				krpc.NodeAddr{source.IP(), port},
+				krpc.NodeAddr{IP: source.IP(), Port: port},
 			)
 		}
 
@@ -1223,7 +1223,7 @@ func (s *Server) closestNodes(k int, target int160.T, filter func(*node) bool) [
 func (s *Server) TraversalStartingNodes() (nodes []addrMaybeId, err error) {
 	s.mu.RLock()
 	s.table.forNodes(func(n *node) bool {
-		nodes = append(nodes, addrMaybeId{n.Addr.KRPC(), &n.Id})
+		nodes = append(nodes, addrMaybeId{Addr: n.Addr.KRPC(), Id: &n.Id})
 		return true
 	})
 	s.mu.RUnlock()
@@ -1243,7 +1243,7 @@ func (s *Server) TraversalStartingNodes() (nodes []addrMaybeId, err error) {
 			// log.Printf("resolved %v addresses", len(addrs))
 		}
 		for _, a := range addrs {
-			nodes = append(nodes, addrMaybeId{a.KRPC(), nil})
+			nodes = append(nodes, addrMaybeId{Addr: a.KRPC(), Id: nil})
 		}
 	}
 	if len(nodes) == 0 {


### PR DESCRIPTION
Hey. Thanks for the great project!

I found this bug when running [server.AnnounceTraversal](https://github.com/afjoseph/dht/blob/ad53c06d69e730ef2e37326658d38259647e5f1a/announce.go#L90).

The current code (below) would either add peers or stop if the traversal is done. This caused the last peer (right before the traversal ends) to be ignored.

```
  select {
  case a.Peers <- psv:
  case <-a.traversal.Stopped():
    return
  default:
  }
```

I changed the code so it **always** gets the last peer and then check if the traversal stopped.

A better approach might be as below. But, I don't think a.Peers will close when that happens. I got no issues like that in my current PR.

```
  select {
  case a.Peers <- psv:
  default:
  }

  select {
  case <-a.traversal.Stopped():
    return
  default:
  }
```

Testing this is tricky since I had multiple nodes I made to recreate this specific scenario. I'll dig a bit to see if I can find an easier way to test.

Cheers and thanks again!
