### PR TITLE
Remove `dht.anacrolix.link`

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -110,7 +110,6 @@ var DefaultGlobalBootstrapHostPorts = []string{
 	"dht.aelitis.com:6881",     // Vuze
 	"router.silotis.us:6881",   // IPv6
 	"dht.libtorrent.org:25401", // @arvidn's
-	"dht.anacrolix.link:42069",
 	"router.bittorrent.cloud:42069",
 }
 


### PR DESCRIPTION
Remove `dht.anacrolix.link` because it doesn't resolve anymore.

```
$ resolvectl query dht.anacrolix.link
dht.anacrolix.link: Name 'dht.anacrolix.link' not found
```

And when using this library then can see
```
lookup dht.anacrolix.link: no such host
```