### PR TITLE
Fix compare-and-swap check for mutable put

### DIFF
--- a/bep44/item.go
+++ b/bep44/item.go
@@ -164,12 +164,10 @@ func CheckIncoming(stored, incoming *Item) error {
 		return ErrSequenceNumberLessThanCurrent
 	}
 
-	// Cas should be ignored if not present
-	if stored.Cas == 0 {
-		return nil
-	}
-
-	if stored.Cas != incoming.Cas {
+	// cas (compare-and-swap) is the sequence number the writer expects to be
+	// replacing; per BEP 44 it must equal the *stored* item's current seq,
+	// otherwise the put is rejected. An absent cas (0) means "no cas".
+	if incoming.Cas != 0 && incoming.Cas != stored.Seq {
 		return ErrCasHashMismatched
 	}
 


### PR DESCRIPTION
`CheckIncoming` compared the *stored* item's `Cas` field against the incoming
item's `Cas`, and returned early (accept) whenever `stored.Cas` was 0. Items are
stored without a meaningful `Cas`, so `stored.Cas` is effectively always 0 and
the compare-and-swap check never fired — a stale update that should be rejected
was accepted, so the lost-update protection `cas` provides did not hold.

Per BEP 44 the incoming put's `cas` is the sequence number the writer expects to
be replacing, and must equal the stored item's current `Seq`. This compares
`incoming.Cas` against `stored.Seq`, treating an absent cas (0) as "no
compare-and-swap requested".

Found with a black-box BEP 44 conformance suite; verified by rebuilding the DHT
server and re-running its `cas` and `cas_type_confusion` checks, which now pass.
