### PR TITLE
Return complete peer addresses from the in-memory store

### DIFF
--- a/krpc/nodeaddr.go
+++ b/krpc/nodeaddr.go
@@ -3,6 +3,7 @@ package krpc
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"net"
 	"net/netip"
 	"strconv"
@@ -32,6 +33,9 @@ func (me NodeAddr) String() string {
 }
 
 func (me *NodeAddr) UnmarshalBinary(b []byte) error {
+	if len(b) < 2 {
+		return fmt.Errorf("unmarshal NodeAddr from %d bytes: need at least 2", len(b))
+	}
 	me.IP = make(net.IP, len(b)-2)
 	copy(me.IP, b[:len(b)-2])
 	me.Port = int(binary.BigEndian.Uint16(b[len(b)-2:]))

--- a/krpc/nodeaddr_test.go
+++ b/krpc/nodeaddr_test.go
@@ -1,6 +1,8 @@
 package krpc
 
 import (
+	"bytes"
+	"encoding/binary"
 	"net"
 	"testing"
 
@@ -13,10 +15,55 @@ var (
 	ParseIP = net.ParseIP
 )
 
-func TestUnmarshalNodeAddr(t *testing.T) {
-	var na NodeAddr
-	require.NoError(t, na.UnmarshalBinary([]byte("\x01\x02\x03\x04\x05\x06")))
-	assert.EqualValues(t, "1.2.3.4", na.IP.String())
+func TestNodeAddrBinaryRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		addr NodeAddr
+	}{
+		{"four-byte IPv4", NodeAddr{IP: net.IP{192, 0, 2, 1}, Port: 0}},
+		{"mapped IPv4", NodeAddr{IP: net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 0, 2, 1}, Port: 65535}},
+		{"global IPv6", NodeAddr{IP: net.IP{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, Port: 6881}},
+		{"link-local IPv6", NodeAddr{IP: net.IP{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, Port: 1}},
+		{"unspecified IPv6", NodeAddr{IP: net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Port: 0}},
+		{"nil IP", NodeAddr{IP: nil, Port: 65535}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoded, err := test.addr.MarshalBinary()
+			require.NoError(t, err)
+
+			var got NodeAddr
+			require.NoError(t, got.UnmarshalBinary(encoded))
+			assert.True(t, bytes.Equal(got.IP, test.addr.IP), "IP = %x, want %x", got.IP, test.addr.IP)
+			assert.Equal(t, test.addr.Port, got.Port)
+		})
+	}
+}
+
+func FuzzNodeAddrUnmarshalBinary(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1})
+	f.Add([]byte{0, 0})
+	f.Add([]byte{1, 2, 3, 4, 0x1a, 0xe1})
+	f.Add([]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0xff, 0xff})
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		original := NodeAddr{IP: net.IP{192, 0, 2, 1}, Port: 6881}
+		got := NodeAddr{IP: bytes.Clone(original.IP), Port: original.Port}
+
+		err := got.UnmarshalBinary(b)
+		if len(b) < 2 {
+			require.Error(t, err)
+			assert.True(t, bytes.Equal(got.IP, original.IP), "receiver IP changed from %x to %x", original.IP, got.IP)
+			assert.Equal(t, original.Port, got.Port)
+			return
+		}
+
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(got.IP, b[:len(b)-2]), "IP = %x, want %x", got.IP, b[:len(b)-2])
+		assert.Equal(t, int(binary.BigEndian.Uint16(b[len(b)-2:])), got.Port)
+	})
 }
 
 var naEqualTests = []struct {

--- a/peer-store/in-memory.go
+++ b/peer-store/in-memory.go
@@ -36,8 +36,15 @@ var _ interface {
 func (me *InMemory) GetPeers(ih InfoHash) (ret []krpc.NodeAddr) {
 	me.mu.RLock()
 	defer me.mu.RUnlock()
-	for _, v := range me.index[ih] {
-		ret = append(ret, v.NodeAddr)
+	nodes := me.index[ih]
+	if len(nodes) == 0 {
+		return
+	}
+	ret = make([]krpc.NodeAddr, len(nodes))
+	i := 0
+	for _, v := range nodes {
+		ret[i] = v.NodeAddr
+		i++
 	}
 	return
 }

--- a/peer-store/in-memory.go
+++ b/peer-store/in-memory.go
@@ -21,7 +21,8 @@ type InMemory struct {
 	index  map[InfoHash]indexValue
 }
 
-// A uniqueness key for entries to the entry details
+// Keys are raw IP bytes used only for uniqueness. NodeAndTime values are
+// authoritative for endpoint and timestamp data.
 type indexValue = map[string]NodeAndTime
 
 type debugWriterInterface interface {
@@ -35,13 +36,8 @@ var _ interface {
 func (me *InMemory) GetPeers(ih InfoHash) (ret []krpc.NodeAddr) {
 	me.mu.RLock()
 	defer me.mu.RUnlock()
-	for b := range me.index[ih] {
-		var r krpc.NodeAddr
-		err := r.UnmarshalBinary([]byte(b))
-		if err != nil {
-			panic(err)
-		}
-		ret = append(ret, r)
+	for _, v := range me.index[ih] {
+		ret = append(ret, v.NodeAddr)
 	}
 	return
 }

--- a/peer-store/in-memory_test.go
+++ b/peer-store/in-memory_test.go
@@ -1,0 +1,268 @@
+package peer_store
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anacrolix/dht/v2/krpc"
+)
+
+type comparableNodeAddr struct {
+	ip   string
+	port int
+}
+
+func makeComparableNodeAddr(na krpc.NodeAddr) comparableNodeAddr {
+	return comparableNodeAddr{string(na.IP), na.Port}
+}
+
+func requireExactNodeAddr(t *testing.T, got, want krpc.NodeAddr) {
+	t.Helper()
+	if !bytes.Equal(got.IP, want.IP) || got.Port != want.Port {
+		t.Fatalf("NodeAddr = {IP: %x, Port: %d}, want {IP: %x, Port: %d}", got.IP, got.Port, want.IP, want.Port)
+	}
+}
+
+func requireNodeAddrSet(t *testing.T, got, want []krpc.NodeAddr) {
+	t.Helper()
+	gotCounts := make(map[comparableNodeAddr]int, len(got))
+	wantCounts := make(map[comparableNodeAddr]int, len(want))
+	for _, na := range got {
+		gotCounts[makeComparableNodeAddr(na)]++
+	}
+	for _, na := range want {
+		wantCounts[makeComparableNodeAddr(na)]++
+	}
+	if len(gotCounts) != len(wantCounts) {
+		t.Fatalf("GetPeers returned %v, want unordered set %v", got, want)
+	}
+	for key, count := range wantCounts {
+		if gotCounts[key] != count {
+			t.Fatalf("GetPeers returned %v, want unordered set %v", got, want)
+		}
+	}
+}
+
+func TestInMemoryPeerStoreRoundTripsNodeAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		addr krpc.NodeAddr
+	}{
+		{"four-byte IPv4 with zero port", krpc.NodeAddr{IP: net.IP{192, 0, 2, 1}, Port: 0}},
+		{"mapped IPv4 with port one", krpc.NodeAddr{IP: net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 0, 2, 1}, Port: 1}},
+		{"global IPv6", krpc.NodeAddr{IP: net.IP{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, Port: 6881}},
+		{"link-local IPv6", krpc.NodeAddr{IP: net.IP{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, Port: 65535}},
+		{"unspecified IPv4", krpc.NodeAddr{IP: net.IP{0, 0, 0, 0}, Port: 6881}},
+		{"unspecified IPv6", krpc.NodeAddr{IP: net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Port: 0}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var store InMemory
+			var ih InfoHash
+			store.AddPeer(ih, test.addr)
+
+			got := store.GetPeers(ih)
+			if len(got) != 1 {
+				t.Fatalf("GetPeers returned %d peers, want 1", len(got))
+			}
+			requireExactNodeAddr(t, got[0], test.addr)
+		})
+	}
+}
+
+func TestInMemoryPeerStoreSameIPDifferentPorts(t *testing.T) {
+	var store InMemory
+	var ih InfoHash
+	ip := net.IP{203, 0, 113, 9}
+	store.AddPeer(ih, krpc.NodeAddr{IP: ip, Port: 1})
+	want := krpc.NodeAddr{IP: ip, Port: 65535}
+	store.AddPeer(ih, want)
+
+	got := store.GetPeers(ih)
+	if len(got) != 1 {
+		t.Fatalf("GetPeers returned %d peers, want 1", len(got))
+	}
+	requireExactNodeAddr(t, got[0], want)
+}
+
+func TestInMemoryPeerStoreKeepsIPv4RepresentationsDistinct(t *testing.T) {
+	var store InMemory
+	var ih InfoHash
+	fourByte := krpc.NodeAddr{IP: net.IP{192, 0, 2, 1}, Port: 6881}
+	mapped := krpc.NodeAddr{IP: net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 0, 2, 1}, Port: 6881}
+	store.AddPeer(ih, fourByte)
+	store.AddPeer(ih, mapped)
+
+	requireNodeAddrSet(t, store.GetPeers(ih), []krpc.NodeAddr{fourByte, mapped})
+}
+
+func TestInMemoryPeerStoreRefreshesDuplicate(t *testing.T) {
+	var ih InfoHash
+	ip := net.IP{198, 51, 100, 7}
+	oldTime := time.Unix(1, 0)
+	store := InMemory{index: map[InfoHash]indexValue{
+		ih: {
+			string(ip): {NodeAddr: krpc.NodeAddr{IP: ip, Port: 1}, Time: oldTime},
+		},
+	}}
+	want := krpc.NodeAddr{IP: ip, Port: 6881}
+
+	store.AddPeer(ih, want)
+
+	got := store.GetAll()[ih]
+	if len(got) != 1 {
+		t.Fatalf("GetAll returned %d peers, want 1", len(got))
+	}
+	requireExactNodeAddr(t, got[0].NodeAddr, want)
+	if !got[0].Time.After(oldTime) {
+		t.Fatalf("refreshed time = %v, want after %v", got[0].Time, oldTime)
+	}
+}
+
+func TestInMemoryPeerStoreDifferentIPsSamePort(t *testing.T) {
+	var store InMemory
+	var ih InfoHash
+	first := krpc.NodeAddr{IP: net.IP{192, 0, 2, 1}, Port: 6881}
+	second := krpc.NodeAddr{IP: net.IP{192, 0, 2, 2}, Port: 6881}
+	store.AddPeer(ih, first)
+	store.AddPeer(ih, second)
+
+	requireNodeAddrSet(t, store.GetPeers(ih), []krpc.NodeAddr{first, second})
+}
+
+func TestInMemoryPeerStoreUnknownInfoHash(t *testing.T) {
+	var store InMemory
+	var ih InfoHash
+	if got := store.GetPeers(ih); len(got) != 0 {
+		t.Fatalf("GetPeers returned %v, want no peers", got)
+	}
+}
+
+func TestInMemoryPeerStoreOpaqueShortIPs(t *testing.T) {
+	var store InMemory
+	var peerStore Interface = &store
+	var ih InfoHash
+	want := []krpc.NodeAddr{
+		{IP: nil, Port: 0},
+		{IP: net.IP{1}, Port: 65535},
+	}
+	for _, addr := range want {
+		peerStore.AddPeer(ih, addr)
+	}
+
+	requireNodeAddrSet(t, peerStore.GetPeers(ih), want)
+}
+
+func TestInMemoryPeerStoreDoesNotMutateCallerIP(t *testing.T) {
+	var store InMemory
+	var ih InfoHash
+	ip := net.IP{192, 0, 2, 44}
+	before := bytes.Clone(ip)
+
+	store.AddPeer(ih, krpc.NodeAddr{IP: ip, Port: 6881})
+
+	if !bytes.Equal(ip, before) {
+		t.Fatalf("caller IP changed from %x to %x", before, ip)
+	}
+}
+
+func TestInMemoryPeerStoreConcurrentAccess(t *testing.T) {
+	var store InMemory
+	var ih InfoHash
+	endpoints := []krpc.NodeAddr{
+		{IP: net.IP{192, 0, 2, 1}, Port: 6001},
+		{IP: net.IP{192, 0, 2, 2}, Port: 6002},
+		{IP: net.IP{192, 0, 2, 3}, Port: 6003},
+		{IP: net.IP{192, 0, 2, 4}, Port: 6004},
+		{IP: net.IP{192, 0, 2, 5}, Port: 6005},
+		{IP: net.IP{192, 0, 2, 6}, Port: 6006},
+		{IP: net.IP{192, 0, 2, 7}, Port: 6007},
+		{IP: net.IP{192, 0, 2, 8}, Port: 6008},
+	}
+	known := make(map[comparableNodeAddr]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		known[makeComparableNodeAddr(endpoint)] = struct{}{}
+	}
+
+	start := make(chan struct{})
+	writersDone := make(chan struct{})
+	readerErrors := make(chan error, 4)
+	var writers sync.WaitGroup
+	var readers sync.WaitGroup
+
+	for _, endpoint := range endpoints {
+		endpoint := endpoint
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			<-start
+			for range 100 {
+				store.AddPeer(ih, endpoint)
+			}
+		}()
+	}
+	for range 4 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			<-start
+			for {
+				select {
+				case <-writersDone:
+					return
+				default:
+				}
+				got := store.GetPeers(ih)
+				if len(got) > len(endpoints) {
+					readerErrors <- fmt.Errorf("GetPeers returned %d peers, maximum is %d", len(got), len(endpoints))
+					return
+				}
+				for _, peer := range got {
+					if _, ok := known[makeComparableNodeAddr(peer)]; !ok {
+						readerErrors <- fmt.Errorf("GetPeers returned unexpected peer %v", peer)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	close(start)
+	writers.Wait()
+	close(writersDone)
+	readers.Wait()
+	close(readerErrors)
+	for err := range readerErrors {
+		t.Error(err)
+	}
+	requireNodeAddrSet(t, store.GetPeers(ih), endpoints)
+}
+
+func FuzzInMemoryPeerStoreRoundTrip(f *testing.F) {
+	f.Add([]byte{192, 0, 2, 1}, uint16(0))
+	f.Add([]byte{255, 255, 255, 255}, uint16(65535))
+	f.Add([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, uint16(1))
+	f.Add([]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, uint16(65535))
+
+	f.Fuzz(func(t *testing.T, rawIP []byte, port uint16) {
+		if len(rawIP) != net.IPv4len && len(rawIP) != net.IPv6len {
+			t.Skip()
+		}
+		var store InMemory
+		var ih InfoHash
+		want := krpc.NodeAddr{IP: net.IP(bytes.Clone(rawIP)), Port: int(port)}
+
+		store.AddPeer(ih, want)
+
+		got := store.GetPeers(ih)
+		if len(got) != 1 {
+			t.Fatalf("GetPeers returned %d peers, want 1", len(got))
+		}
+		requireExactNodeAddr(t, got[0], want)
+	})
+}


### PR DESCRIPTION
## Problem

`InMemory.AddPeer` uses the raw `net.IP` bytes as the uniqueness key while storing the complete address and timestamp in `NodeAndTime`. `GetPeers` incorrectly decoded that IP-only key as `IP || uint16(port)`, truncating the returned IP and deriving a false port from its final two bytes.

The mismatch originated when commit `7275ed3c` changed peer identity to one latest entry per raw IP while retaining the complete endpoint as the map value.

## Change

- Return the authoritative stored `NodeAndTime.NodeAddr` values from `GetPeers`.
- Preserve raw-IP uniqueness and latest-write replacement for a changed port.
- Pre-size the result slice from the locked map size, reducing multi-peer retrieval to one allocation without changing empty-result behavior.
- Document the key/value invariant.
- Reject `NodeAddr.UnmarshalBinary` inputs shorter than two bytes before touching the receiver.
- Add deterministic, concurrent, and fuzz coverage for peer-store identity, endpoint round trips, timestamp refresh, malformed binary input, and port boundaries.

## Performance

External `BenchmarkGetPeers` measurements on Darwin/arm64, Apple M2, Go 1.26.6 (`-benchtime=500ms -count=5`, medians):

| Peers | Before | After | Allocations |
| ---: | ---: | ---: | ---: |
| 1 | 62.7 ns, 32 B | 62.2 ns, 32 B | 1 -> 1 |
| 8 | 175.3 ns, 480 B | 97.4 ns, 256 B | 4 -> 1 |
| 64 | 1,164 ns, 4,448 B | 734 ns, 2,304 B | 7 -> 1 |
| 1,024 | 20,839 ns, 119,392 B | 11,491 ns, 32,768 B | 12 -> 1 |

## Compatibility

Public method signatures and `peer_store.Interface` are unchanged. Raw four-byte IPv4 and mapped 16-byte IPv4 representations remain distinct keys. Valid `NodeAddr` binary encoding remains the raw IP prefix followed by the big-endian uint16 port. Compact KRPC helpers continue to canonicalize their respective IPv4 and IPv6 wire representations.

### Out of scope

This focused fix intentionally leaves the following independent behaviors unchanged:

- IPv6 zone support
- peer expiry, capacity limits, and persistence
- sorted peer results
- defensive copying of caller-owned IP slices
- endpoint-based uniqueness

Endpoint-based uniqueness is not adopted here because commit `7275ed3c` deliberately established one latest peer per raw IP. The other items would introduce separate storage, ownership, or performance contracts and are better evaluated independently if maintainers want them.

## Validation

Passed locally on Darwin/arm64:

- Go 1.23.12: repeated package tests, race tests, and `go vet` for `./peer-store ./krpc`
- `go test -count=50 ./peer-store ./krpc`
- `go test -race -count=100 ./peer-store -run '^TestInMemoryPeerStoreConcurrentAccess$'`
- 30-second fuzz campaigns for both semantic fuzz targets; more than 3.3M peer-store and 1.4M NodeAddr executions
- `go test -race -count 2 -bench . ./...`
- `go test -run @ -bench . ./...`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

Independent adversarial, concurrency/platform, and code-review agents reported no findings. A public API harness confirmed `1.2.3.4:6881` round-trips exactly.

Fixes #79
